### PR TITLE
feat: Return JSON error responses with application/json content type

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func entitlements(w http.ResponseWriter, r *http.Request) {
 	userObj, err := kc.GetUser(w, r)
 
 	if err != nil {
-		http.Error(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
+		writeJSONError(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
 		return
 	}
 
@@ -55,9 +55,10 @@ func entitlements(w http.ResponseWriter, r *http.Request) {
 	var v interface{}
 	jsonErr := json.Unmarshal([]byte(entitlements), &v)
 	if jsonErr != nil {
-		http.Error(w, jsonErr.Error(), http.StatusInternalServerError)
+		writeJSONError(w, jsonErr.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprint(w, entitlements)
 }
 
@@ -65,11 +66,18 @@ func compliance(w http.ResponseWriter, r *http.Request) {
 	_, err := kc.GetUser(w, r)
 
 	if err != nil {
-		http.Error(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
+		writeJSONError(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprint(w, "\"result\": \"OK\"\n\"description\":\"\" ")
+}
+
+func writeJSONError(w http.ResponseWriter, message string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
 }
 
 // MUST VALIDATE THAT THE BEARER TOKEN HAD THE RIGHT SCOPES

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func entitlements(w http.ResponseWriter, r *http.Request) {
 	userObj, err := kc.GetUser(w, r)
 
 	if err != nil {
-		writeJSONError(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
+		http.Error(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
 		return
 	}
 
@@ -55,10 +55,9 @@ func entitlements(w http.ResponseWriter, r *http.Request) {
 	var v interface{}
 	jsonErr := json.Unmarshal([]byte(entitlements), &v)
 	if jsonErr != nil {
-		writeJSONError(w, jsonErr.Error(), http.StatusInternalServerError)
+		http.Error(w, jsonErr.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprint(w, entitlements)
 }
 
@@ -66,18 +65,11 @@ func compliance(w http.ResponseWriter, r *http.Request) {
 	_, err := kc.GetUser(w, r)
 
 	if err != nil {
-		writeJSONError(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
+		http.Error(w, "couldn't auth user: "+err.Error(), http.StatusForbidden)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprint(w, "\"result\": \"OK\"\n\"description\":\"\" ")
-}
-
-func writeJSONError(w http.ResponseWriter, message string, status int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
 }
 
 // MUST VALIDATE THAT THE BEARER TOKEN HAD THE RIGHT SCOPES

--- a/serviceaccounts/service_accounts.go
+++ b/serviceaccounts/service_accounts.go
@@ -31,6 +31,30 @@ type serviceAccountInput struct {
 	Description string `json:"description"`
 }
 
+type statusError struct {
+	status  int
+	message string
+}
+
+func (e statusError) Error() string {
+	return e.message
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Add("access-control-allow-origin", "*")
+	if status != http.StatusOK {
+		w.WriteHeader(status)
+	}
+	return json.NewEncoder(w).Encode(v)
+}
+
+func writeJSONError(w http.ResponseWriter, message string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
 func ServiceAccountHandler(w http.ResponseWriter, r *http.Request, kc *keycloak.Instance) {
 	var err error
 	// Default HTTP error status is 500
@@ -49,9 +73,13 @@ func ServiceAccountHandler(w http.ResponseWriter, r *http.Request, kc *keycloak.
 		err = optionsServiceAccount(w, r)
 	}
 	if err != nil {
-		errString := fmt.Sprintf("%s", err)
+		status := httpErrorStatus
+		var se statusError
+		if errors.As(err, &se) {
+			status = se.status
+		}
 		kc.Log.Error(err, "error running function: ")
-		http.Error(w, errString, httpErrorStatus)
+		writeJSONError(w, err.Error(), status)
 	}
 }
 
@@ -97,10 +125,7 @@ func createServiceAccount(w http.ResponseWriter, r *http.Request, kc *keycloak.I
 		return fmt.Errorf("there was an error constructing the JSON output object: %w", err)
 	}
 
-	w.Header().Add("access-control-allow-origin", "*")
-	w.WriteHeader(http.StatusCreated)
-	fmt.Fprint(w, string(outputBytes))
-	return nil
+	return writeJSON(w, http.StatusCreated, json.RawMessage(outputBytes))
 }
 
 func getOrgInfo(r *http.Request) (string, string, error) {
@@ -163,9 +188,7 @@ func getServiceAccountList(w http.ResponseWriter, r *http.Request, kc *keycloak.
 	if err != nil {
 		return fmt.Errorf("couldn't marshal serviceAccountList: %w", err)
 	}
-	w.Header().Add("access-control-allow-origin", "*")
-	fmt.Fprint(w, string(outputUsers))
-	return nil
+	return writeJSON(w, http.StatusOK, json.RawMessage(outputUsers))
 }
 
 func getSingleServiceAccount(w http.ResponseWriter, r *http.Request, kc *keycloak.Instance, uuid string) error {
@@ -211,9 +234,7 @@ func getSingleServiceAccount(w http.ResponseWriter, r *http.Request, kc *keycloa
 	if err != nil {
 		return fmt.Errorf("couldn't marshal serviceAccountList: %w", err)
 	}
-	w.Header().Add("access-control-allow-origin", "*")
-	fmt.Fprint(w, string(outputUsers))
-	return nil
+	return writeJSON(w, http.StatusOK, json.RawMessage(outputUsers))
 }
 
 func getServiceAccounts(w http.ResponseWriter, r *http.Request, kc *keycloak.Instance) error {
@@ -230,8 +251,10 @@ func getServiceAccounts(w http.ResponseWriter, r *http.Request, kc *keycloak.Ins
 		return getServiceAccountList(w, r, kc)
 	}
 
-	http.Error(w, "Malformed input: expected UUID or collection path", http.StatusBadRequest)
-	return errors.New("malformed input: neither UUID nor collection path")
+	return statusError{
+		status:  http.StatusBadRequest,
+		message: "malformed input: neither UUID nor collection path",
+	}
 }
 
 func deleteServiceAccount(w http.ResponseWriter, r *http.Request, kc *keycloak.Instance) error {


### PR DESCRIPTION
## Summary

Aligns mocktitlements error handling with JSON API expectations by returning structured error bodies and setting `Content-Type: application/json` on failure responses.

- **Service accounts** (`serviceaccounts/service_accounts.go`):
  - Introduces `writeJSON` / `writeJSONError` helpers for consistent success and error responses.
  - Adds `statusError` so handlers can return specific HTTP status codes (e.g. `400 Bad Request` for malformed paths) without relying on handler-level defaults.
  - Success responses (create, list, get) use the shared JSON writer with CORS headers preserved.

## Motivation

Clients consuming the mock API expect JSON error payloads and a proper `Content-Type` header. Plain-text errors from `http.Error` break JSON parsers and differ from production API behavior.